### PR TITLE
Use strings as internal representation for URIs instead of  URIRefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .coverage
 cov.xml
 .env
+dist

--- a/stwfsapy/tests/common.py
+++ b/stwfsapy/tests/common.py
@@ -44,15 +44,25 @@ thsrs_broader = [
     (test_thesaurus_ref_100, test_thesaurus_ref_10),
     ]
 
-test_concept_ref_0_0 = URIRef("http://test.org/concept/0_0")
-test_concept_ref_01_0 = URIRef("http://test.org/concept/01_0")
-test_concept_ref_01_00 = URIRef("http://test.org/concept/01_00")
-test_concept_ref_10_0 = URIRef("http://test.org/concept/10_0")
-test_concept_ref_10_1 = URIRef("http://test.org/concept/10_1")
-test_concept_ref_100_0 = URIRef("http://test.org/concept/100_0")
-test_concept_ref_100_00 = URIRef("http://test.org/concept/100_00")
-test_concept_ref_100_01 = URIRef("http://test.org/concept/100_01")
-test_concept_ref_100_02 = URIRef("http://test.org/concept/100_02")
+test_concept_uri_0_0 = "http://test.org/concept/0_0"
+test_concept_uri_01_0 = "http://test.org/concept/01_0"
+test_concept_uri_01_00 = "http://test.org/concept/01_00"
+test_concept_uri_10_0 = "http://test.org/concept/10_0"
+test_concept_uri_10_1 = "http://test.org/concept/10_1"
+test_concept_uri_100_0 = "http://test.org/concept/100_0"
+test_concept_uri_100_00 = "http://test.org/concept/100_00"
+test_concept_uri_100_01 = "http://test.org/concept/100_01"
+test_concept_uri_100_02 = "http://test.org/concept/100_02"
+
+test_concept_ref_0_0 = URIRef(test_concept_uri_0_0)
+test_concept_ref_01_0 = URIRef(test_concept_uri_01_0)
+test_concept_ref_01_00 = URIRef(test_concept_uri_01_00)
+test_concept_ref_10_0 = URIRef(test_concept_uri_10_0)
+test_concept_ref_10_1 = URIRef(test_concept_uri_10_1)
+test_concept_ref_100_0 = URIRef(test_concept_uri_100_0)
+test_concept_ref_100_00 = URIRef(test_concept_uri_100_00)
+test_concept_ref_100_01 = URIRef(test_concept_uri_100_01)
+test_concept_ref_100_02 = URIRef(test_concept_uri_100_02)
 
 test_labels = [
     (test_concept_ref_0_0, Literal("concept-0_0", lang="en")),

--- a/stwfsapy/tests/predictor_test.py
+++ b/stwfsapy/tests/predictor_test.py
@@ -75,7 +75,7 @@ def patched_dfa(mocker):
 
     def mock_search(text):
         for i in range(len(text)):
-            yield (i*2+9, text)
+            yield (str(i*2+9), text)
 
     mocker.patch.object(dfa, "search", mock_search)
     return dfa
@@ -141,9 +141,9 @@ def test_match_and_extend_with_truth(patched_dfa):
         [[], [11, 14], [9]]
     )
     assert concepts == [
-        (9, "a"), (9, "bbb"),
-        (11, "bbb"), (13, "bbb"),
-        (9, "xx"), (11, "xx")]
+        ("9", "a"), ("9", "bbb"),
+        ("11", "bbb"), ("13", "bbb"),
+        ("9", "xx"), ("11", "xx")]
     assert ys == [0, 0, 1, 0, 1, 0]
 
 
@@ -152,9 +152,9 @@ def test_match_and_extend_without_truth(patched_dfa):
     predictor.dfa_ = patched_dfa
     concepts, counts = predictor.match_and_extend(["a", "bbb", "xx"])
     assert concepts == [
-        (9, "a"), (9, "bbb"),
-        (11, "bbb"), (13, "bbb"),
-        (9, "xx"), (11, "xx")]
+        ("9", "a"), ("9", "bbb"),
+        ("11", "bbb"), ("13", "bbb"),
+        ("9", "xx"), ("11", "xx")]
     assert counts == [1, 3, 2]
 
 
@@ -183,10 +183,10 @@ def test_init_and_fit(full_graph, mocker):
     predictor._fit_after_init(train_texts, y=train_labels)
     spy_fit.assert_called_once_with(
         [
-            (c.test_concept_ref_0_0, "concept-0_0"),
-            (c.test_concept_ref_100_00, "Concept-100_00"),
-            (c.test_concept_ref_10_0, "concept-10_0"),
-            (c.test_concept_ref_01_00, "concept-01_00"),
+            (c.test_concept_uri_0_0, "concept-0_0"),
+            (c.test_concept_uri_100_00, "Concept-100_00"),
+            (c.test_concept_uri_10_0, "concept-10_0"),
+            (c.test_concept_uri_01_00, "concept-01_00"),
             ],
         [1, 0, 1, 1]
     )

--- a/stwfsapy/tests/thesaurus_features_test.py
+++ b/stwfsapy/tests/thesaurus_features_test.py
@@ -65,12 +65,12 @@ def test_fit(full_graph):
         assert x.shape[1] == 6
     # Can not test positions because retrieval from graph is not deterministic.
     # Therefore, test non zero entries only.
-    assert mapping[c.test_concept_ref_0_0].getnnz() == 1
-    assert mapping[c.test_concept_ref_01_0].getnnz() == 2
-    assert mapping[c.test_concept_ref_01_00].getnnz() == 2
-    assert mapping[c.test_concept_ref_10_0].getnnz() == 2
-    assert mapping[c.test_concept_ref_10_1].getnnz() == 2
-    assert mapping[c.test_concept_ref_100_0].getnnz() == 3
-    assert mapping[c.test_concept_ref_100_00].getnnz() == 3
-    assert mapping[c.test_concept_ref_100_01].getnnz() == 3
-    assert mapping[c.test_concept_ref_100_02].getnnz() == 3
+    assert mapping[c.test_concept_uri_0_0].getnnz() == 1
+    assert mapping[c.test_concept_uri_01_0].getnnz() == 2
+    assert mapping[c.test_concept_uri_01_00].getnnz() == 2
+    assert mapping[c.test_concept_uri_10_0].getnnz() == 2
+    assert mapping[c.test_concept_uri_10_1].getnnz() == 2
+    assert mapping[c.test_concept_uri_100_0].getnnz() == 3
+    assert mapping[c.test_concept_uri_100_00].getnnz() == 3
+    assert mapping[c.test_concept_uri_100_01].getnnz() == 3
+    assert mapping[c.test_concept_uri_100_02].getnnz() == 3

--- a/stwfsapy/thesaurus_features.py
+++ b/stwfsapy/thesaurus_features.py
@@ -35,7 +35,7 @@ class ThesaurusFeatureTransformation(BaseEstimator, TransformerMixin):
         self.thesauri = thesauri
         self.mapping_ = None
 
-    def fit(self, X=None, y=None):
+    def fit(self, X=None, y=None, **kwargs):
         """Creates the mapping from concepts
         to the thesauri that are broader than the concept."""
         broaders = list(t.extract_broader(self.graph))
@@ -60,7 +60,7 @@ class ThesaurusFeatureTransformation(BaseEstimator, TransformerMixin):
             for concept, broaders in concept_po.items()
         }
         self.mapping_ = {
-            concept: csr_matrix(
+            str(concept): csr_matrix(
                 (
                     [1 for _ in thesaurii],
                     (


### PR DESCRIPTION
Previously rdflib URI refs were used for internal representation of URIs. This PR removes the wrapper.