### PR TITLE
Document concept pooling

### DIFF
--- a/stwfsapy/predictor.py
+++ b/stwfsapy/predictor.py
@@ -347,8 +347,9 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
             return concepts, doc_counts
 
     def _mark_last_concept_in_doc(self, concepts):
-        last = concepts.pop()
-        concepts.append((last[0], last[1], last[2], 1))
+        if concepts:
+            last = concepts.pop()
+            concepts.append((last[0], last[1], last[2], 1))
 
     def store(self, path):
         with ZipFile(path, 'w') as zfile:

--- a/stwfsapy/predictor.py
+++ b/stwfsapy/predictor.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-from typing import FrozenSet, List, Iterable, Container, Tuple, TypeVar, Union
+from typing import DefaultDict, Dict, FrozenSet, List, Iterable, \
+    Container, Tuple, TypeVar, Union
 from logging import getLogger
 from rdflib.term import URIRef
 from rdflib import Graph
@@ -225,7 +226,7 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
             predictions = []
         return self._create_sparse_matrix(
             predictions,
-            match_X,
+            [tpl[0] for tpl in match_X],
             doc_counts
         )
 
@@ -242,7 +243,7 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
             predictions = []
         combined = StwfsapyPredictor._collect_prediction_results(
             predictions,
-            match_X,
+            [tpl[0] for tpl in match_X],
             doc_counts
         )
         return [
@@ -263,14 +264,14 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
             predictions = []
         return self._create_sparse_matrix(
             predictions,
-            match_X,
+            [tpl[0] for tpl in match_X],
             doc_counts
         )
 
     def _create_sparse_matrix(
             self,
             values: Nl,
-            tuples: List[Tuple[T, str]],
+            concept_names: List[str],
             doc_counts: List[int]
             ) -> csr_matrix:
         return csr_matrix(
@@ -285,9 +286,9 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
                         in range(doc_counts[doc_idx])
                         ],
                     [
-                        self.concept_map_.get(tpl[0])
-                        for tpl
-                        in tuples
+                        self.concept_map_.get(name)
+                        for name
+                        in concept_names
                     ]
                 )),
             shape=(len(doc_counts), len(self.concept_map_))
@@ -296,14 +297,14 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
     @staticmethod
     def _collect_prediction_results(
             values: Nl,
-            tuples: List[Tuple[T, str]],
+            concept_names: List[T],
             doc_counts: List[int]
             ) -> List[Tuple[List[T], Nl]]:
         ret = []
         start = 0
         for count in doc_counts:
             end = start+count
-            ret.append(([t[0] for t in tuples[start:end]], values[start:end]))
+            ret.append((concept_names[start:end], values[start:end]))
             start = end
         return ret
 
@@ -311,7 +312,7 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
             self,
             texts: Iterable[str],
             truth_refss: Iterable[Container] = None
-            ) -> Tuple[List[Tuple[str, str]], List[int]]:
+            ) -> Tuple[List[Tuple[str, str, List[int], int]], List[int]]:
         """Retrieves concepts by their labels from text.
         If ground truth values are present,
         it will also return a list of labels for scoring matches.
@@ -321,23 +322,33 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
         if truth_refss is not None:
             ret_y = []
             for text, truth_refs in zip(texts, map(str, truth_refss)):
+                matched_concepts: Dict[str, List[int]] = DefaultDict(list)
                 for match in self.dfa_.search(text):
                     concept = match[0]
-                    text = match[1]
-                    concepts.append((concept, text))
+                    position = match[2]
+                    matched_concepts[concept].append(position)
+                for concept, positions in matched_concepts.items():
+                    concepts.append((concept, text, positions, 0))
                     ret_y.append(int(concept in truth_refs))
+                self._mark_last_concept_in_doc(concepts)
             return concepts, ret_y
         else:
             doc_counts: List[int] = []
             for text in texts:
-                count = 0
+                matched_concepts = DefaultDict(list)
                 for match in self.dfa_.search(text):
-                    count += 1
                     concept = match[0]
-                    text = match[1]
-                    concepts.append((concept, text))
-                doc_counts.append(count)
+                    position = match[2]
+                    matched_concepts[concept].append(position)
+                for concept, positions in matched_concepts.items():
+                    concepts.append((concept, text, positions, 0))
+                self._mark_last_concept_in_doc(concepts)
+                doc_counts.append(len(matched_concepts))
             return concepts, doc_counts
+
+    def _mark_last_concept_in_doc(self, concepts):
+        last = concepts.pop()
+        concepts.append((last[0], last[1], last[2], 1))
 
     def store(self, path):
         with ZipFile(path, 'w') as zfile:

--- a/stwfsapy/predictor.py
+++ b/stwfsapy/predictor.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-from typing import DefaultDict, Dict, FrozenSet, List, Iterable, \
+from collections import defaultdict
+from typing import Dict, FrozenSet, List, Iterable, \
     Container, Tuple, TypeVar, Union
 from logging import getLogger
 from rdflib.term import URIRef
@@ -322,7 +323,7 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
         if truth_refss is not None:
             ret_y = []
             for text, truth_refs in zip(texts, map(str, truth_refss)):
-                matched_concepts: Dict[str, List[int]] = DefaultDict(list)
+                matched_concepts: Dict[str, List[int]] = defaultdict(list)
                 for match in self.dfa_.search(text):
                     concept = match[0]
                     position = match[2]
@@ -335,7 +336,7 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
         else:
             doc_counts: List[int] = []
             for text in texts:
-                matched_concepts = DefaultDict(list)
+                matched_concepts = defaultdict(list)
                 for match in self.dfa_.search(text):
                     concept = match[0]
                     position = match[2]

--- a/stwfsapy/tests/predictor_test.py
+++ b/stwfsapy/tests/predictor_test.py
@@ -369,7 +369,7 @@ def test_expansion(full_graph, mocker):
         assert call(label_text) in stub.mock_calls
 
 
-def test_mark_doc_end_empty():
+def test_mark_doc_end():
     predictor = p.StwfsapyPredictor(None, None, None, None)
     matches = [('a', 'aa', [0], 0), ('b', 'bbb', [2, 5], 0)]
     res = predictor._mark_last_concept_in_doc(matches)
@@ -378,7 +378,7 @@ def test_mark_doc_end_empty():
         ('b', 'bbb', [2, 5], 1)]
 
 
-def test_mark_doc():
+def test_mark_doc_end_empty():
     predictor = p.StwfsapyPredictor(None, None, None, None)
     lst = []
     predictor._mark_last_concept_in_doc(lst)

--- a/stwfsapy/tests/predictor_test.py
+++ b/stwfsapy/tests/predictor_test.py
@@ -45,7 +45,7 @@ train_texts = [
     "nothing",
     "concept",
     "has Concept-100_00 in the middle",
-    "concept-10_0 and concept-01_00",
+    "concept-10_0 and concept-01_00 and concept-10_0",
     ]
 train_labels = [
     [c.test_concept_ref_0_0],
@@ -76,7 +76,8 @@ def patched_dfa(mocker):
 
     def mock_search(text):
         for i in range(len(text)):
-            yield (str(i*2+9), text)
+            for j in range(i+1):
+                yield (str(i*2+9), text, j)
 
     mocker.patch.object(dfa, "search", mock_search)
     return dfa
@@ -116,7 +117,7 @@ def case_graph():
 def test_result_collection():
     res = p.StwfsapyPredictor._collect_prediction_results(
         _predictions[:, 1],
-        _concepts_with_text,
+        [c[0] for c in _concepts_with_text],
         _doc_counts
     )
     assert [(r[0], list(r[1])) for r in res] == _collection_result
@@ -127,7 +128,7 @@ def test_sparse_matrix_creation():
     predictor.concept_map_ = _concept_map
     res = predictor._create_sparse_matrix(
         _predictions[:, 1],
-        _concepts_with_text,
+        [c[0] for c in _concepts_with_text],
         _doc_counts
     )
     assert res.shape[0] == len(_doc_counts)
@@ -151,9 +152,9 @@ def test_match_and_extend_with_truth(patched_dfa):
         [[], [11, 14], [9]]
     )
     assert concepts == [
-        ("9", "a"), ("9", "bbb"),
-        ("11", "bbb"), ("13", "bbb"),
-        ("9", "xx"), ("11", "xx")]
+        ("9", "a", [0], 1), ("9", "bbb", [0], 0),
+        ("11", "bbb", [0, 1], 0), ("13", "bbb", [0, 1, 2], 1),
+        ("9", "xx", [0], 0), ("11", "xx", [0, 1], 1)]
     assert ys == [0, 0, 1, 0, 1, 0]
 
 
@@ -162,9 +163,9 @@ def test_match_and_extend_without_truth(patched_dfa):
     predictor.dfa_ = patched_dfa
     concepts, counts = predictor.match_and_extend(["a", "bbb", "xx"])
     assert concepts == [
-        ("9", "a"), ("9", "bbb"),
-        ("11", "bbb"), ("13", "bbb"),
-        ("9", "xx"), ("11", "xx")]
+        ("9", "a", [0], 1), ("9", "bbb", [0], 0),
+        ("11", "bbb", [0, 1], 0), ("13", "bbb", [0, 1, 2], 1),
+        ("9", "xx", [0], 0), ("11", "xx", [0, 1], 1)]
     assert counts == [1, 3, 2]
 
 
@@ -195,10 +196,14 @@ def test_init_and_fit(full_graph, mocker):
     predictor._fit_after_init(train_texts, y=train_labels)
     spy_fit.assert_called_once_with(
         [
-            (c.test_concept_uri_0_0, "concept-0_0"),
-            (c.test_concept_uri_100_00, "Concept-100_00"),
-            (c.test_concept_uri_10_0, "concept-10_0"),
-            (c.test_concept_uri_01_00, "concept-01_00"),
+            (c.test_concept_uri_0_0, "concept-0_0", [0], 1),
+            (
+                c.test_concept_uri_100_00,
+                "has Concept-100_00 in the middle",
+                [4],
+                1),
+            (c.test_concept_uri_10_0, train_texts[-1], [0, 35], 0),
+            (c.test_concept_uri_01_00, train_texts[-1], [17], 1),
             ],
         [1, 0, 1, 1]
     )

--- a/stwfsapy/tests/predictor_test.py
+++ b/stwfsapy/tests/predictor_test.py
@@ -369,6 +369,22 @@ def test_expansion(full_graph, mocker):
         assert call(label_text) in stub.mock_calls
 
 
+def test_mark_doc_end_empty():
+    predictor = p.StwfsapyPredictor(None, None, None, None)
+    matches = [('a', 'aa', [0], 0), ('b', 'bbb', [2, 5], 0)]
+    res = predictor._mark_last_concept_in_doc(matches)
+    assert matches == [
+        ('a', 'aa', [0], 0),
+        ('b', 'bbb', [2, 5], 1)]
+
+
+def test_mark_doc():
+    predictor = p.StwfsapyPredictor(None, None, None, None)
+    lst = []
+    predictor._mark_last_concept_in_doc(lst)
+    assert lst == []
+
+
 def test_uriref_str_inversion():
     ref = c.test_type_concept
     assert ref == p._load_uri_ref(p._store_uri_ref(ref))


### PR DESCRIPTION
The changes in this patch will group matched concepts for a document. This will prevent a s single concept to be scored twice for a given document.