### PR TITLE
Allow rdflib versions smaller than 7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ readme_txt = (file_dir / "Readme.md").read_text()
 
 setup(
     name="stwfsapy",
-    version="0.02.1",
+    version="0.03.0",
     description="A library for match labels of thesaurus concepts to text" + (
         " and assigning scores to found occurrences."),
     long_description=readme_txt,
@@ -25,7 +25,8 @@ setup(
     ],
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
-    install_requires=["rdflib>=4.2,<6.0", "scikit-learn>=0.24.*"],
+    install_requires=["rdflib>=4.2,<7.0", "scikit-learn>=0.24.*"],
+    install_requires=["rdflib>=4.2,<7.0", "scikit-learn>=0.22.*"],
     tests_require=['py', 'pytest', 'pytest-mock'],
     extras_require={
         'dev': [


### PR DESCRIPTION
Allow for newer versions of rdflib. This was requested by a annif user.