### PR TITLE
Set year to 2025 inside Copyright notice.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 # -- Project information
 
 project = 'stwfsapy'
-copyright = '2021-2023, AutoSE'
+copyright = '2020-2025, AutoSE'
 author = 'AutoSE'
 
 # -- General configuration

--- a/stwfsapy/automata/construction.py
+++ b/stwfsapy/automata/construction.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/automata/conversion.py
+++ b/stwfsapy/automata/conversion.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/automata/dfa.py
+++ b/stwfsapy/automata/dfa.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/automata/heap.py
+++ b/stwfsapy/automata/heap.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/automata/nfa.py
+++ b/stwfsapy/automata/nfa.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/case_handlers.py
+++ b/stwfsapy/case_handlers.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/expansion.py
+++ b/stwfsapy/expansion.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/frequency_features.py
+++ b/stwfsapy/frequency_features.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/position_features.py
+++ b/stwfsapy/position_features.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/predictor.py
+++ b/stwfsapy/predictor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/conftest.py
+++ b/stwfsapy/tests/automata/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/construction_test.py
+++ b/stwfsapy/tests/automata/construction_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/conversion_test.py
+++ b/stwfsapy/tests/automata/conversion_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/data.py
+++ b/stwfsapy/tests/automata/data.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/dfa_test.py
+++ b/stwfsapy/tests/automata/dfa_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/heap_test.py
+++ b/stwfsapy/tests/automata/heap_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/integration_test.py
+++ b/stwfsapy/tests/automata/integration_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/nfa_test.py
+++ b/stwfsapy/tests/automata/nfa_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/automata/search_overlap_regression_test.py
+++ b/stwfsapy/tests/automata/search_overlap_regression_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/case_handlers_test.py
+++ b/stwfsapy/tests/case_handlers_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/common.py
+++ b/stwfsapy/tests/common.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/conftest.py
+++ b/stwfsapy/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/expansion/ampersand_expansion_test.py
+++ b/stwfsapy/tests/expansion/ampersand_expansion_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/expansion/any_case_from_braces_test.py
+++ b/stwfsapy/tests/expansion/any_case_from_braces_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/expansion/base_expansion_test.py
+++ b/stwfsapy/tests/expansion/base_expansion_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/expansion/collect_test.py
+++ b/stwfsapy/tests/expansion/collect_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/expansion/common.py
+++ b/stwfsapy/tests/expansion/common.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/expansion/expand_abbreviation_with_puntuation_test.py
+++ b/stwfsapy/tests/expansion/expand_abbreviation_with_puntuation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/expansion/simple_english_plural_test.py
+++ b/stwfsapy/tests/expansion/simple_english_plural_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/expansion/upper_case_abbreviations_from_braces_test.py
+++ b/stwfsapy/tests/expansion/upper_case_abbreviations_from_braces_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/frequency_features_test.py
+++ b/stwfsapy/tests/frequency_features_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/position_features_test.py
+++ b/stwfsapy/tests/position_features_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/predictor_test.py
+++ b/stwfsapy/tests/predictor_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/text_features_test.py
+++ b/stwfsapy/tests/text_features_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/common.py
+++ b/stwfsapy/tests/thesaurus/common.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/conftest.py
+++ b/stwfsapy/tests/thesaurus/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/extract_by_type_uri_test.py
+++ b/stwfsapy/tests/thesaurus/extract_by_type_uri_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/extract_deprecated_test.py
+++ b/stwfsapy/tests/thesaurus/extract_deprecated_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/extract_labels_test.py
+++ b/stwfsapy/tests/thesaurus/extract_labels_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/extract_relation_by_uri_test.py
+++ b/stwfsapy/tests/thesaurus/extract_relation_by_uri_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/label_unwrapping_test.py
+++ b/stwfsapy/tests/thesaurus/label_unwrapping_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/language_filter_test.py
+++ b/stwfsapy/tests/thesaurus/language_filter_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/retrieve_concept_labels_test.py
+++ b/stwfsapy/tests/thesaurus/retrieve_concept_labels_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus/set_filter_test.py
+++ b/stwfsapy/tests/thesaurus/set_filter_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/thesaurus_features_test.py
+++ b/stwfsapy/tests/thesaurus_features_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/util/input_handler_test.py
+++ b/stwfsapy/tests/util/input_handler_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/util/passthrough_transformer_test.py
+++ b/stwfsapy/tests/util/passthrough_transformer_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/tests/util/set_closure_test.py
+++ b/stwfsapy/tests/util/set_closure_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/text_features.py
+++ b/stwfsapy/text_features.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/thesaurus.py
+++ b/stwfsapy/thesaurus.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/thesaurus_features.py
+++ b/stwfsapy/thesaurus_features.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/util/input_handler.py
+++ b/stwfsapy/util/input_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/util/passthrough_transformer.py
+++ b/stwfsapy/util/passthrough_transformer.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stwfsapy/util/set_closure.py
+++ b/stwfsapy/util/set_closure.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Leibniz Information Centre for Economics
+# Copyright 2020-2025 Leibniz Information Centre for Economics
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Relevant issue: #75 


Background info: `# any relevant background info for additional context, references to documentations etc.`

- Each `python` script inside our repository comes with a Copyright notice specified at the top. The year specified in this notice needs to be updated.


Changes introduced: `# list changes to the code repo made in this pull request`

- The year inside each Copyright notice provided in this repository has been changed from `2024` to `2025`.
- In one instance, `docs/source/conf.py`, the year provided was `2021` and it was changed to `2020`.
