### PR TITLE
Update docs and bump version number for new release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,9 +15,9 @@ authors:
     affiliation: "ZBW - Leibniz Information Centre for Economics"
 title: "stwfsapy (a library for matching labels of thesaurus concepts via finite-state automata)"
 abstract: "This library provides functionality to find the labels of SKOS thesaurus concepts in text. A deterministic finite automaton is constructed from the labels of the thesaurus concepts to perform the matching. In addition, a classifier is trained to score the matched concept occurrences."
-version: 0.5.4
+version: 0.6.0
 license: Apache-2.0
-date-released: 2025-03-13
+date-released: 2025-04-29
 repository-code: "https://github.com/zbw/stwfsapy"
 contact:
   - name: "Automatization of subject indexing using methods from artificial intelligence (AutoSE)"

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,3 +5,4 @@ API
 .. automodule:: stwfsapy.predictor
    :members:
    :undoc-members:
+   :exclude-members: set_score_request

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,4 +5,4 @@ API
 .. automodule:: stwfsapy.predictor
    :members:
    :undoc-members:
-   
+   :exclude-members: set_score_request

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,4 +5,4 @@ API
 .. automodule:: stwfsapy.predictor
    :members:
    :undoc-members:
-   :exclude-members: set_score_request
+   

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,6 @@
 # -- Path setup --------------------------------------------------------------
 
 import os
-import re
 import sys
 
 sys.path.insert(0, os.path.abspath("../.."))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,3 @@ epub_show_urls = 'footnote'
 
 autoclass_content = "both" 
 autodoc_typehints = "none"
-autodoc_default_options = {
-    'members': True,
-    'inherited-members': False,  # Disable inherited methods
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stwfsapy"
-version = "0.5.4"
+version = "0.6.0"
 description = "A library for match labels of thesaurus concepts to text and assigning scores to found occurrences."
 authors = ["AutoSE <autose@zbw.eu>"]
 license = "Apache-2.0"

--- a/stwfsapy/predictor.py
+++ b/stwfsapy/predictor.py
@@ -479,6 +479,11 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
             concepts.append((last[0], last[1], last[2], last[3], last[4], 1))
 
     def store(self, path):
+        """
+        Stores a predictor instance into a zip file.
+
+        :params  path: Path to the zip file storing the trained predictor.
+        """
         with ZipFile(path, 'w') as zfile:
             with zfile.open(_NAME_PREDICTOR_FILE, 'w', force_zip64=True) as fp:
                 fp.write(

--- a/stwfsapy/predictor.py
+++ b/stwfsapy/predictor.py
@@ -483,6 +483,8 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
         Stores a predictor instance into a zip file.
 
         :params  path: Path to the zip file storing the trained predictor.
+
+        Returns: None
         """
         with ZipFile(path, 'w') as zfile:
             with zfile.open(_NAME_PREDICTOR_FILE, 'w', force_zip64=True) as fp:

--- a/stwfsapy/predictor.py
+++ b/stwfsapy/predictor.py
@@ -484,7 +484,8 @@ class StwfsapyPredictor(BaseEstimator, ClassifierMixin):
 
         :params  path: Path to the zip file storing the trained predictor.
 
-        Returns: None
+        Returns: 
+            None
         """
         with ZipFile(path, 'w') as zfile:
             with zfile.open(_NAME_PREDICTOR_FILE, 'w', force_zip64=True) as fp:


### PR DESCRIPTION
Relevant issue: #85 


Background info: `# any relevant background info for additional context, references to documentations etc.`

- `set_score_request` method should be removed from our docs as it is not implemented inside `stwfsapy/predictor.py`
- `python v3.9` has been dropped in pull request #84 . 
- We need to bump the version number and date-released to make a new release.


Changes introduced: `# list changes to the code repo made in this pull request`

- In `docs/source/api.rst` we exclude `set_score_request` method.
- `version` bumped in `pyproject.toml`.
- `version` and `date-released` modified in `CITATION.CFF`.
