### PR TITLE
Add quotes around version number for python in workflow files.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
           cache: 'poetry'
 
       - name: Install dependencies
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Build and upload to PyPI
         env:


### PR DESCRIPTION
Relevant issue: #87 


Background info: `# any relevant background info for additional context, references to documentations etc.`

- The python version is not being properly parsed for in our workflow files. 
- Quotes should be added around the python version so that they are properly parsed.


Changes introduced: `# list changes to the code repo made in this pull request`

- The `python-version` key has a version value in quotes for the `.github/workflows/publish.yml` file .
