### PR TITLE
Update the version of rdflib

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,9 +15,9 @@ authors:
     affiliation: "ZBW - Leibniz Information Centre for Economics"
 title: "stwfsapy (a library for matching labels of thesaurus concepts via finite-state automata)"
 abstract: "This library provides functionality to find the labels of SKOS thesaurus concepts in text. A deterministic finite automaton is constructed from the labels of the thesaurus concepts to perform the matching. In addition, a classifier is trained to score the matched concept occurrences."
-version: 0.6.2
+version: 0.7.0
 license: Apache-2.0
-date-released: 2025-12-12
+date-released: 2026-02-09
 repository-code: "https://github.com/zbw/stwfsapy"
 contact:
   - name: "Automatization of subject indexing using methods from artificial intelligence (AutoSE)"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each training sample should be annotated with one or more concepts from the thes
 Python ``>= 3.10,<3.14`` is required.
 
 ### With pip
-stwfsapy is available on [PyPI](pypi.org) . You can install stwfsapy using pip:
+stwfsapy is available on [PyPI](https://pypi.org) . You can install stwfsapy using pip:
 
 ``pip install stwfsapy``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stwfsapy"
-version = "0.6.2"
+version = "0.7.0"
 description = "A library for match labels of thesaurus concepts to text and assigning scores to found occurrences."
 authors = [{name ="AutoSE", email = "autose@zbw.eu"}]
 requires-python = ">=3.10,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 dependencies=[
     "scipy~=1.15",
     "scikit-learn>0.24,<2.0",
-    "rdflib~=7.1"
+    "rdflib~=7.5"
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1547,7 +1547,7 @@ wheels = [
 
 [[package]]
 name = "stwfsapy"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "rdflib" },

--- a/uv.lock
+++ b/uv.lock
@@ -1573,7 +1573,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "rdflib", specifier = "~=7.1" },
+    { name = "rdflib", specifier = "~=7.5" },
     { name = "scikit-learn", specifier = ">0.24,<2.0" },
     { name = "scipy", specifier = "~=1.15" },
 ]


### PR DESCRIPTION
Relevant issue: #113 


Background info: `# any relevant background info for additional context, references to documentations etc.`

- There is a new minor version of `rdflib` available.
- We should bump `rdflib`.


Changes introduced: `# list changes to the code repo made in this pull request`

- The version of `rdflib` has been bumped to `v7.5`.
- A new `uv.lock` has been generated.
- The url link to `PyPI` has been fixed in the `README`. 

Once these changes have been reviewed I shall change the version number and date released. Thereafter, I will make a new release.
